### PR TITLE
Revert `allow_resend_from` behavior change

### DIFF
--- a/Mail/Outgoing.pm
+++ b/Mail/Outgoing.pm
@@ -400,12 +400,16 @@ sub _rewrite_from {
         return 0;
     }
     my($cfg) = $self->internal_get_config;
-    if ($cfg->{allow_resend_from_re} && $old_email =~ $cfg->{allow_resend_from_re}) {
-        return 1;
+    if ($cfg->{allow_resend_from_re}) {
+        if ($old_email =~ $cfg->{allow_resend_from_re}) {
+            return 1;
+        }
     }
-    my($d) = lc($_E->get_domain_part($old_email));
-    if (!_rewrite_from_lookup($d)) {
-        return 1;
+    else {
+        my($d) = lc($_E->get_domain_part($old_email));
+        if (!_rewrite_from_lookup($d)) {
+            return 1;
+        }
     }
     my($new_email, $new_name) = _rewrite_from_generate(
         $self, $old_email, $old_name, $req);


### PR DESCRIPTION
This reverts commit 6e5b2c66401e51c53c0a2ba25f9b4f1661e85782, which changed rewrite behavior when `allow_resend_from` is set. It was previously believed that was only relevant to tests, but it is used in prod as well. Should reevaluate how that config should affect rewrites.