### PR TITLE
Fix #68 Require new passwords to be >= 8 chars, allow existing 6-7 char passwords

### DIFF
--- a/Biz/Model/UserCreateForm.pm
+++ b/Biz/Model/UserCreateForm.pm
@@ -8,6 +8,7 @@ b_use('IO.ClassLoaderAUTOLOAD');
 
 my($_DN) = b_use('Type.DisplayName');
 my($_A) = b_use('IO.Alert');
+my($_P) = b_use('Type.Password');
 my($_GUEST) = b_use('Auth.Role')->GUEST;
 my($_USER) = $_GUEST->USER;
 my($_C) = b_use('IO.Config');
@@ -149,6 +150,11 @@ sub validate {
             || $self->get_field_error('confirm_password')
             || $self->get('RealmOwner.password')
                 eq $self->get('confirm_password');
+    return
+        if $self->in_error;
+    my($validate_err) = $_P->validate_clear_text($self->get('RealmOwner.password'));
+    $self->internal_put_error('RealmOwner.password', $validate_err)
+        if $validate_err;
     return;
 }
 

--- a/Biz/Model/UserOTPForm.pm
+++ b/Biz/Model/UserOTPForm.pm
@@ -50,6 +50,7 @@ sub internal_pre_execute {
 
 sub internal_validate_new {
     my($self) = @_;
+    # Not calling super as new password isn't a regular password
     my($otp) = Bivio::Biz::RFC2289->canonical_hex($self->get('new_password'));
     unless ($otp) {
         $self->internal_put_field(new_password => undef);

--- a/Biz/Model/UserPasswordForm.pm
+++ b/Biz/Model/UserPasswordForm.pm
@@ -4,6 +4,7 @@ use strict;
 use Bivio::Base 'Biz.FormModel';
 
 my($_LAS) = b_use('Type.LoginAttemptState');
+my($_P) = b_use('Type.Password');
 
 sub PASSWORD_FIELD_LIST {
     return qw(new_password old_password confirm_new_password);
@@ -58,16 +59,20 @@ sub internal_pre_execute {
 }
 
 sub internal_validate_new {
+    my($self) = @_;
+    my($error) = $_P->validate_clear_text($self->get('new_password'));
+    return $self->internal_put_error('new_password', $error)
+        if $error;
     return;
 }
 
 sub internal_validate_old {
     my($self) = @_;
     return $self->internal_put_error(qw(old_password PASSWORD_MISMATCH))
-        unless $self->use('Type.Password')->is_equal(
+        unless $_P->is_equal(
             $self->req(qw(auth_realm owner password)),
             $self->get('old_password'),
-    );
+        );
     return 1;
 }
 

--- a/Biz/Model/t/UserCreateForm2.bunit
+++ b/Biz/Model/t/UserCreateForm2.bunit
@@ -1,0 +1,40 @@
+# Copyright (c) 2005 bivio Software, Inc.  All Rights Reserved.
+FormModel();
+[
+    error_case({
+        'RealmOwner.display_name' => 'Some User',
+        'Email.email' => email('some_user'),
+        'RealmOwner.password' => 'password1',
+        confirm_password => 'password2',
+    } => {
+        'RealmOwner.password' => 'CONFIRM_PASSWORD',
+    }),
+    error_case({
+        'RealmOwner.display_name' => 'Some User',
+        'Email.email' => email('some_user'),
+        'RealmOwner.password' => 'pass',
+        confirm_password => 'pass',
+    } => {
+        'RealmOwner.password' => 'TOO_SHORT',
+    }),
+    # Separate code path for 6-7 character passwords
+    error_case({
+        'RealmOwner.display_name' => 'Some User',
+        'Email.email' => email('some_user'),
+        'RealmOwner.password' => 'passwd',
+        confirm_password => 'passwd',
+    } => {
+        'RealmOwner.password' => 'TOO_SHORT',
+    }),
+    simple_case({
+        'RealmOwner.display_name' => 'Some User',
+        'Email.email' => email('some_user'),
+        'RealmOwner.password' => 'password',
+        confirm_password => 'password',
+    } => {
+        'RealmOwner.display_name' => 'Some User',
+        'Email.email' => email('some_user'),
+        'RealmOwner.password' => 'password',
+        confirm_password => 'password',
+    }),
+];

--- a/Biz/Model/t/UserLoginForm4.bunit
+++ b/Biz/Model/t/UserLoginForm4.bunit
@@ -1,0 +1,39 @@
+# Copyright (c) 2023 bivio Software, Inc.  All Rights Reserved.
+FormModel();
+my($reset_password) = sub {
+    my($password) = @_;
+    req()->with_realm_and_user(qw(demo demo), sub {
+        Util_RealmAdmin()->reset_password($password);
+    });
+    return 1;
+};
+[
+    simple_case({
+        login => 'demo',
+        'RealmOwner.password' => 'password',
+    } => {
+        login => 'demo',
+        'RealmOwner.password' => 'password',
+    }),
+    inline_case(sub {
+        return $reset_password->('passwd');
+    }),
+    # Users are allowed to log in with existing deprecated 6-7 character passwords
+    simple_case({
+        login => 'demo',
+        'RealmOwner.password' => 'passwd',
+    } => {
+        login => 'demo',
+        'RealmOwner.password' => 'passwd',
+    }),
+    inline_case(sub {
+        return $reset_password->('pass');
+    }),
+    # Users are not allowed to log in with invalid < 6 character passwords
+    simple_case({
+        login => 'demo',
+        'RealmOwner.password' => 'pass',
+    } => {
+        'RealmOwner.password' => 'TOO_SHORT',
+    }),
+];

--- a/Biz/Model/t/UserPasswordForm.bunit
+++ b/Biz/Model/t/UserPasswordForm.bunit
@@ -1,5 +1,4 @@
-# Copyright (c) 2007 bivio Software, Inc.  All Rights Reserved.
-# $Id$
+# Copyright (c) 2007-2023 bivio Software, Inc.  All Rights Reserved.
 FormModel();
 req()->set_realm_and_user(qw(demo demo));
 [
@@ -8,6 +7,8 @@ req()->set_realm_and_user(qw(demo demo));
         new_password => 'password',
         confirm_new_password => 'password',
     } => {
+        new_password => 'password',
+        confirm_new_password => 'password',
     }),
     error_case({
         old_password => '',
@@ -15,6 +16,21 @@ req()->set_realm_and_user(qw(demo demo));
         confirm_new_password => 'password',
     } => {
         old_password => 'NULL',
+    }),
+    error_case({
+        old_password => 'password',
+        new_password => 'pass',
+        confirm_new_password => 'pass',
+    } => {
+        new_password => 'TOO_SHORT',
+    }),
+    # There is a separate validation mechanism for 6-7 char passwords
+    error_case({
+        old_password => 'password',
+        new_password => 'passwd',
+        confirm_new_password => 'passwd',
+    } => {
+        new_password => 'TOO_SHORT',
     }),
     error_case({
         old_password => 'badbad',
@@ -42,5 +58,7 @@ req()->set_realm_and_user(qw(demo demo));
         new_password => 'password',
         confirm_new_password => 'password',
     } => {
+        new_password => 'password',
+        confirm_new_password => 'password',
     }),
 ];

--- a/Type/Password.pm
+++ b/Type/Password.pm
@@ -1,5 +1,4 @@
-# Copyright (c) 1999-2007 bivio Software, Inc.  All rights reserved.
-# $Id$
+# Copyright (c) 1999-2023 bivio Software, Inc.  All rights reserved.
 package Bivio::Type::Password;
 use strict;
 use Bivio::Base 'Type.Name';
@@ -51,6 +50,8 @@ sub encrypt {
 }
 
 sub get_min_width {
+    # As of 07/2023, new passwords are required to be 8 characters, but we are allowing existing
+    # short passwords.
     return 6;
 }
 
@@ -74,6 +75,15 @@ sub is_valid {
             || $value =~ $_VALID_SHA_RE
             || $value eq $proto->OTP_VALUE
     ) ? 1 : 0;
+}
+
+sub validate_clear_text {
+    my($proto, $clear_text, $user_id, $user_name, $user_emails) = @_;
+    # Have to check length outside of usual width checking as deprecated 6-7 character passwords are
+    # still allowed.
+    return 'TOO_SHORT'
+        if length($clear_text) < 8;
+    return;
 }
 
 sub _encrypt {

--- a/Type/Password.pm
+++ b/Type/Password.pm
@@ -78,7 +78,7 @@ sub is_valid {
 }
 
 sub validate_clear_text {
-    my($proto, $clear_text, $user_id, $user_name, $user_emails) = @_;
+    my($proto, $clear_text) = @_;
     # Have to check length outside of usual width checking as deprecated 6-7 character passwords are
     # still allowed.
     return 'TOO_SHORT'

--- a/Type/t/Password.t
+++ b/Type/t/Password.t
@@ -35,5 +35,9 @@ Bivio::Test->new('Bivio::Type::Password')->unit([
             otp => 1,
             xx => 0,
         ],
+        validate_clear_text => [
+            'shrtpw' => 'TOO_SHORT',
+            'longerpw' => undef,
+        ],
     ],
 ]);


### PR DESCRIPTION
Builds upon #70 