### PR TITLE
Fix email pw link head reqs

### DIFF
--- a/Biz/Action/AccessChallenge.pm
+++ b/Biz/Action/AccessChallenge.pm
@@ -145,6 +145,9 @@ sub execute_assert_escalation_if_mfa {
 
 sub execute_password_reset {
     my($proto, $req) = @_;
+    # Don't use access code if called by link-checker or other HEAD request
+    return
+        if $req->is_http_method('HEAD');
     my($query_key) = delete(($req->get('query') || {})->{$_PASSWORD_QUERY_KEY});
     my($u) = $req->get_nested(qw(auth_realm owner));
     my($res);

--- a/Delegate/TaskId.pm
+++ b/Delegate/TaskId.pm
@@ -1543,6 +1543,7 @@ sub info_user_auth {
             USER
             ANYBODY
             Action.AccessChallenge->execute_password_reset
+            Action.EmptyReply
             plain_task=USER_PASSWORD
             password_task=USER_PASSWORD
             totp_task=USER_LOGIN_TOTP_FORM

--- a/PetShop/Test/t/password.btest
+++ b/PetShop/Test/t/password.btest
@@ -67,7 +67,11 @@ do_logout();
 (my $bad = $uri) =~ s/(?<=\=)\S//;
 visit_uri($bad);
 verify_text('no longer valid');
+visit_uri($uri, 'HEAD');
+b_die('unexpected content')
+    if length(get_content()) > 0;
 visit_uri($uri);
+verify_no_text('no longer valid');
 verify_text(qr/(sign-out|\blogout\b)/i);
 verify_no_text('Current Password');
 submit_form('Cancel');

--- a/Test/Language/HTTP.pm
+++ b/Test/Language/HTTP.pm
@@ -1161,11 +1161,14 @@ sub visit_realm_folder {
 }
 
 sub visit_uri {
-    my($self, $uri) = @_;
+    my($self, $uri, $method) = @_;
+    $method ||= 'GET';
+    b_die('unexpected method')
+        unless $method =~ qr/(GET|HEAD)/;
     # Loads the page using the specified URI.
     _trace($uri) if $_TRACE;
 #TODO: No referer when we are visiting
-    _send_request($self, HTTP::Request->new(GET => $self->absolute_uri($uri)));
+    _send_request($self, HTTP::Request->new($method => $self->absolute_uri($uri)));
     return;
 }
 


### PR DESCRIPTION
Previously, HEAD requests to password links (as some email clients execute to check or preview links) would invalidate the link.