### PR TITLE
fix #126 handle wide characters

### DIFF
--- a/MIME/Base64.pm
+++ b/MIME/Base64.pm
@@ -1,5 +1,4 @@
-# Copyright (c) 2000-2008 bivio Software, Inc.  All rights reserved.
-# $Id$
+# Copyright (c) 2000-2026 Bivio Software, Inc.  All rights reserved.
 package Bivio::MIME::Base64;
 use strict;
 use Bivio::Base 'Bivio::UNIVERSAL';
@@ -34,6 +33,10 @@ sub http_encode {
     # Converts I<decoded> to an encoded form using the rules for
     # http-base64 encoding.
     my(undef, $decoded) = @_;
+    # MIME::Base64::encode dies on wide characters; downgrade to UTF-8 octets.
+    # Binary input (Random, Secret) has the flag off and is left untouched.
+    utf8::encode($decoded)
+        if defined($decoded) && utf8::is_utf8($decoded);
     my($encoded) = MIME::Base64::encode($decoded, '');
     $encoded =~ tr/=+\//_*-/;
     return $encoded;

--- a/MIME/t/Base64.bunit
+++ b/MIME/t/Base64.bunit
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Bivio Software, Inc.  All rights reserved.
+my($_B) = b_use('MIME.Base64');
+[
+    class() => [
+        {
+            method => 'http_encode',
+            compute_return => sub {
+                my($case, $actual) = @_;
+                return [$_B->http_decode($actual->[0])];
+            },
+        } => [
+            ["Bivio Software\x{2763}\x{fe0f}"]
+                => [do {my($x) = "Bivio Software\x{2763}\x{fe0f}"; utf8::encode($x); $x}],
+            # Binary input (flag off) is left untouched.
+            [join('', map(chr, 0 .. 255))] => [join('', map(chr, 0 .. 255))],
+        ],
+    ],
+];


### PR DESCRIPTION
Encode wide characters so that `MIME::Base64::encode` can handle them. `MIME::Base64::decode` already handles encoded wide characters correctly.